### PR TITLE
Minor improvements

### DIFF
--- a/lua/nvim-lastplace/init.lua
+++ b/lua/nvim-lastplace/init.lua
@@ -3,11 +3,14 @@ local lastplace = {}
 
 function lastplace:setup(options)
 	options = options or {}
-	lastplace.options = options	
+	lastplace.options = options
 	lastplace:set_option("lastplace_ignore_buftype",{'quickfix','nofile','help'})
 	lastplace:set_option("lastplace_ignore_filetype",{'gitcommit','gitrebase','svn','hgcommit'})
 	lastplace:set_option("lastplace_open_folds", 1)
-	vim.cmd[[autocmd BufWinEnter * lua require'nvim-lastplace'.lastplace_func()]]
+	vim.cmd[[augroup NvimLastplace]]
+	vim.cmd[[  autocmd!]]
+	vim.cmd[[  autocmd BufReadPost * lua require'nvim-lastplace'.lastplace_func()]]
+	vim.cmd[[augroup end]]
 end
 
 function lastplace:set_option(option,default)
@@ -29,25 +32,21 @@ function lastplace:lastplace_func()
 	for i,v in ipairs(lastplace.options.lastplace_ignore_filetype) do
 		if v == ft then return end
 	end
-	-- Check if file exists, if so load
-	local file = fn.empty(fn.glob(fn.expand('%@')))
-	if file then
-		-- If the last line is set and the less than the last line in the buffer
-		if fn.line([['"]]) > 0 and fn.line([['"]]) <= fn.line("$") then
-			--Check if the last line of the buffer is the same as the window 
-			if fn.line("w$") == fn.line("$") then
-				--Set line to last line edited
-				vim.api.nvim_command([[normal! g`"]])
+	-- If the last line is set and the less than the last line in the buffer
+	if fn.line([['"]]) > 0 and fn.line([['"]]) <= fn.line("$") then
+		--Check if the last line of the buffer is the same as the window 
+		if fn.line("w$") == fn.line("$") then
+			--Set line to last line edited
+			vim.api.nvim_command([[normal! g`"]])
 			-- Try to center
-			elseif fn.line("$") - fn.line([['"]]) > ((fn.line("w$") - fn.line("w0")) / 2) - 1 then
-				vim.api.nvim_command([[normal! g`"zz]])
-			else
-				vim.api.nvim_command([[normal! G'"<c-e>]])
-			end
+		elseif fn.line("$") - fn.line([['"]]) > ((fn.line("w$") - fn.line("w0")) / 2) - 1 then
+			vim.api.nvim_command([[normal! g`"zz]])
+		else
+			vim.api.nvim_command([[normal! G'"<c-e>]])
 		end
-		if fn.foldclosed(".") ~= -1 and lastplace.options.lastplace_open_folds == 1 then
-			vim.api.nvim_command([[normal! zvzz]])
-		end
+	end
+	if fn.foldclosed(".") ~= -1 and lastplace.options.lastplace_open_folds == 1 then
+		vim.api.nvim_command([[normal! zvzz]])
 	end
 end
 

--- a/lua/nvim-lastplace/init.lua
+++ b/lua/nvim-lastplace/init.lua
@@ -23,15 +23,14 @@ function lastplace:set_option(option,default)
 end
 
 function lastplace:lastplace_func()
-	-- Get buffer and filetype
-	local buf = vim.bo.buftype
-	local ft = vim.bo.filetype
-	for i,v in ipairs(lastplace.options.lastplace_ignore_buftype) do
-		if v == buf then return end
+	-- Check if buffer should be ignored
+	if vim.tbl_contains(lastplace.options.lastplace_ignore_buftype,
+			vim.api.nvim_buf_get_option(0, 'buftype')) or
+		vim.tbl_contains(lastplace.options.lastplace_ignore_filetype,
+			vim.api.nvim_buf_get_option(0, 'filetype')) then
+		return
 	end
-	for i,v in ipairs(lastplace.options.lastplace_ignore_filetype) do
-		if v == ft then return end
-	end
+
 	-- If the last line is set and the less than the last line in the buffer
 	if fn.line([['"]]) > 0 and fn.line([['"]]) <= fn.line("$") then
 		--Check if the last line of the buffer is the same as the window 


### PR DESCRIPTION
I replaced `BufWinEnter` with `BufReadPost` As suggested by [monkoose](https://www.reddit.com/r/neovim/comments/nix1xb/nvimlastplace_a_lua_rewrite_of_vimlastplace_for/gz59hen?utm_source=share&utm_medium=web2x&context=3) to avoid extra check.
Also I used `vim.tbl_contains` call to check if array contains a value.

I would suggest to use spaces instead of tabs. This is how it done in other plugins.