### PR TITLE
Fix:  Doesn't center view around cursor at the top of a file #11

### DIFF
--- a/lua/nvim-lastplace/init.lua
+++ b/lua/nvim-lastplace/init.lua
@@ -30,7 +30,7 @@ function lastplace.setup(options)
 	set_option("lastplace_open_folds", 1)
 	vim.cmd([[augroup NvimLastplace]])
 	vim.cmd([[  autocmd!]])
-	vim.cmd([[  autocmd VimEnter,BufRead * lua require('nvim-lastplace').lastplace()]])
+	vim.cmd([[  autocmd BufWinEnter * lua require('nvim-lastplace').lastplace()]])
 	vim.cmd([[augroup end]])
 end
 


### PR DESCRIPTION
Fixes #11, doesn't break #9 and works with paq, packer and plug.

Merges both autocommands to one.

https://github.com/ethanholz/nvim-lastplace/blob/30fe710d4417cc67950bbce6b2ec2ac0ff430e12/lua/nvim-lastplace/init.lua#L33
https://github.com/ethanholz/nvim-lastplace/blob/30fe710d4417cc67950bbce6b2ec2ac0ff430e12/lua/nvim-lastplace/init.lua#L35

Instead of listening to BufReadPost and FileType events the new autocmd listens only for VimEnter and BufReadPost. VimEnter is required to ensure that the cursor is also centered when opening the first buffer right after vim starts. For some reason this is an exception and BufRead isn't enough.

Because both autocmd are merged we can also merge the two functions `lastplace_buf()` and `lastplace_ft()` into a single function `lastplace()`. This also enables to merge the function `set_cursor_position()` into `lastplace()`.