### PR TITLE
Fix issue with filetype autcmd not being added nvim 0.8.0

### DIFF
--- a/lua/nvim-lastplace/init.lua
+++ b/lua/nvim-lastplace/init.lua
@@ -31,7 +31,7 @@ function lastplace.setup(options)
 	vim.cmd([[augroup NvimLastplace]])
 	vim.cmd([[  autocmd!]])
 	vim.cmd([[  autocmd BufReadPost * lua require('nvim-lastplace').lastplace_buf()]])
-	if fn.has('nvim-0.5.1') == 0 then
+	if fn.has('nvim-0.5.1') == 1 then
 		vim.cmd([[  autocmd FileType * lua require('nvim-lastplace').lastplace_ft()]])
 	end
 	vim.cmd([[augroup end]])


### PR DESCRIPTION
I am unsure as to the original intentions of the `== 0` check going on here, but in nvim 0.8.0 it results int he filetype autocommand not being added, with the final result of gitcommit (et. al.) not being ignored properly.

Setting this to `1` (which I assume implies requiring a minimum nvim version of 0.5.1) fixes this issue for me locally.